### PR TITLE
Regex upgrade!

### DIFF
--- a/classes/ReputationManager.js
+++ b/classes/ReputationManager.js
@@ -120,11 +120,11 @@ export default class ReputationManager extends InteractionHandler {
 	_testMessage(message) {
 		return [
 			m => /(?<!no )(?<![A-z])th(a?n?(k|x))?s?(?![A-z])/gi.test(m.content),   // Contains any of the permutations or abbreviations of thanks, but not preceeded by "no"
-			m => /(?<![A-z])ty(vm)?(?![A-z])/gi.test(m.content),                	// Constains "tyvm" or just "ty"
-			m => /(?<![A-z])points? (?:to|for) <@(?![A-z])/gi.test(m.content), 		// Phrase like "a point to [user]" - think Harry Potter
-			m => /(?<![A-z])cheers(?![A-z])/gi.test(m.content),                		// Constains "cheers"
-			m => /(?<![A-z])dankee?(?![A-z])/gi.test(m.content),               		// Constains "danke"
-			m => /:vote:/gi.test(m.content)                                    		// The +1 emoji
+			m => /(?<![A-z])ty(vm)?(?![A-z])/gi.test(m.content),                    // Constains "tyvm" or just "ty"
+			m => /(?<![A-z])points? (?:to|for) <@(?![A-z])/gi.test(m.content),      // Phrase like "a point to [user]" - think Harry Potter
+			m => /(?<![A-z])cheers(?![A-z])/gi.test(m.content),                     // Constains "cheers"
+			m => /(?<![A-z])dankee?(?![A-z])/gi.test(m.content),                    // Constains "danke"
+			m => /:vote:/gi.test(m.content)                                         // The +1 emoji
 		].some(test=> test(message));
 	}
 

--- a/classes/ReputationManager.js
+++ b/classes/ReputationManager.js
@@ -119,12 +119,12 @@ export default class ReputationManager extends InteractionHandler {
 	 */
 	_testMessage(message) {
 		return [
-			m => /(?<!no )(?<![A-z])thanks?(?![A-z])/gi.test(m.content),       // Contains "thank", but not preceeded by "no"
-			m => /(?<![A-z])tyvm(?![A-z])/gi.test(m.content),                  // Constains "tyvm"
-			m => /(?<![A-z])points? (?:to|for) <@(?![A-z])/gi.test(m.content), // Phrase like "a point to [user]" - think Harry Potter
-			m => /(?<![A-z])cheers(?![A-z])/gi.test(m.content),                // Constains "cheers"
-			m => /(?<![A-z])dankee?(?![A-z])/gi.test(m.content),               // Constains "danke"
-			m => /:vote:/gi.test(m.content)                                    // The +1 emoji
+			m => /(?<!no )(?<![A-z])th(a?n?(k|x))?s?(?![A-z])/gi.test(m.content),   // Contains any of the permutations or abbreviations of thanks, but not preceeded by "no"
+			m => /(?<![A-z])ty(vm)?(?![A-z])/gi.test(m.content),                	// Constains "tyvm" or just "ty"
+			m => /(?<![A-z])points? (?:to|for) <@(?![A-z])/gi.test(m.content), 		// Phrase like "a point to [user]" - think Harry Potter
+			m => /(?<![A-z])cheers(?![A-z])/gi.test(m.content),                		// Constains "cheers"
+			m => /(?<![A-z])dankee?(?![A-z])/gi.test(m.content),               		// Constains "danke"
+			m => /:vote:/gi.test(m.content)                                    		// The +1 emoji
 		].some(test=> test(message));
 	}
 


### PR DESCRIPTION
Made the "vm" after "ty" optional
Added support for permutations of thanks.
Here are some examples of abbreviations that are now accepted:

thanks
thank
thnx
thanx
thx