### PR TITLE
Fix #13; Remove matching for undesired misc terms

### DIFF
--- a/classes/ReputationManager.js
+++ b/classes/ReputationManager.js
@@ -119,7 +119,7 @@ export default class ReputationManager extends InteractionHandler {
 	 */
 	_testMessage(message) {
 		return [
-			m => /(?<!no )(?<![A-z])th(a?n?(k|x))?s?(?![A-z])/gi.test(m.content),   // Contains any of the permutations or abbreviations of thanks, but not preceeded by "no"
+			m => /(?<!no )(?<![A-z])th(a?n(k|x(?!s))s?)(?![A-z])/gi.test(m.content),   // Contains any of the permutations or abbreviations of thanks, but not preceeded by "no"
 			m => /(?<![A-z])ty(vm)?(?![A-z])/gi.test(m.content),                	// Constains "tyvm" or just "ty"
 			m => /(?<![A-z])points? (?:to|for) <@(?![A-z])/gi.test(m.content), 		// Phrase like "a point to [user]" - think Harry Potter
 			m => /(?<![A-z])cheers(?![A-z])/gi.test(m.content),                		// Constains "cheers"

--- a/classes/ReputationManager.js
+++ b/classes/ReputationManager.js
@@ -120,11 +120,11 @@ export default class ReputationManager extends InteractionHandler {
 	_testMessage(message) {
 		return [
 			m => /(?<!no )(?<![A-z])th(a?n(k|x(?!s))s?)(?![A-z])/gi.test(m.content),   // Contains any of the permutations or abbreviations of thanks, but not preceeded by "no"
-			m => /(?<![A-z])ty(vm)?(?![A-z])/gi.test(m.content),                	// Constains "tyvm" or just "ty"
-			m => /(?<![A-z])points? (?:to|for) <@(?![A-z])/gi.test(m.content), 		// Phrase like "a point to [user]" - think Harry Potter
-			m => /(?<![A-z])cheers(?![A-z])/gi.test(m.content),                		// Constains "cheers"
-			m => /(?<![A-z])dankee?(?![A-z])/gi.test(m.content),               		// Constains "danke"
-			m => /:vote:/gi.test(m.content)                                    		// The +1 emoji
+			m => /(?<![A-z])ty(vm)?(?![A-z])/gi.test(m.content),                       // Constains "tyvm" or just "ty"
+			m => /(?<![A-z])points? (?:to|for) <@(?![A-z])/gi.test(m.content),         // Phrase like "a point to [user]" - think Harry Potter
+			m => /(?<![A-z])cheers(?![A-z])/gi.test(m.content),                        // Constains "cheers"
+			m => /(?<![A-z])dankee?(?![A-z])/gi.test(m.content),                       // Constains "danke"
+			m => /:vote:/gi.test(m.content)                                            // The +1 emoji
 		].some(test=> test(message));
 	}
 


### PR DESCRIPTION
I've narrowed it down tro I've narrowed it down to only match:

- thank
- thnx
- thnk
- thanx
- thnks
- thanks
- thnxs
- thanxs